### PR TITLE
Update download link in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -68,7 +68,7 @@
   },
   "socket": false,
   "manifest": "https://github.com/EduardoBugs/fvtt-token-action-hud-l5r5e/releases/latest/download/module.json",
-  "download": "https://github.com/EduardoBugs/fvtt-token-action-hud-l5r5e/releases/donwload/1.0.3/module.zip",
+  "download": "https://github.com/EduardoBugs/fvtt-token-action-hud-l5r5e/releases/download/1.0.7/module.zip",
   "readme": "https://github.com/EduardoBugs/fvtt-token-action-hud-l5r5e#readme",
   "protected": false,
   "coreTranslation": false,


### PR DESCRIPTION
The link in module.json targets an unavailable version of the module (1.0.3 instead of 1.0.7)